### PR TITLE
feat: Implement jj-configured branch names

### DIFF
--- a/spr/src/commands/diff.rs
+++ b/spr/src/commands/diff.rs
@@ -773,6 +773,9 @@ fn get_new_branch_name(
     commit_oid: Oid,
     title: &str,
 ) -> Result<String> {
+    if config.use_jj_bookmark_names {
+        return jj.get_jj_bookmark_name_for_commit(commit_oid);
+    }
     find_unused_branch_name(config, jj, &slugify(title))
 }
 
@@ -782,6 +785,10 @@ fn get_base_branch_name(
     commit_oid: Oid,
     title: &str,
 ) -> Result<String> {
+    if config.use_jj_bookmark_names {
+        let name = jj.get_jj_bookmark_name_for_commit(commit_oid)?;
+        return Ok(format!("{}.{}", config.master_ref.branch_name(), name));
+    }
     find_unused_branch_name(
         config,
         jj,
@@ -825,6 +832,7 @@ mod tests {
             "origin".into(),
             "main".into(),
             "spr/test/".into(),
+            false,
             false,
         )
     }

--- a/spr/src/commands/diff.rs
+++ b/spr/src/commands/diff.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     message::{MessageSection, validate_commit_message},
     output::{output, write_commit_title},
-    utils::{parse_name_list, remove_all_parens, run_command},
+    utils::{parse_name_list, remove_all_parens, run_command, slugify},
 };
 use git2::Oid;
 use indoc::{formatdoc, indoc};
@@ -371,9 +371,7 @@ async fn diff_impl(
 
     let pull_request_branch = match &pull_request {
         Some(pr) => pr.head.clone(),
-        None => {
-            config.new_github_branch(&config.get_new_branch_name(&jj.get_all_ref_names()?, title))
-        }
+        None => config.new_github_branch(&get_new_branch_name(config, jj, local_commit.oid, title)?),
     };
 
     // Get the tree ids of the current head of the Pull Request, as well as the
@@ -547,7 +545,7 @@ async fn diff_impl(
         let base_branch = if let Some(base_branch) = base_branch {
             base_branch
         } else {
-            config.new_github_branch(&config.get_base_branch_name(&jj.get_all_ref_names()?, title))
+            config.new_github_branch(&get_base_branch_name(config, jj, local_commit.oid, title)?)
         };
 
         (Some(new_base_branch_commit), Some(base_branch))
@@ -767,6 +765,51 @@ async fn diff_impl(
     }
 
     Ok(())
+}
+
+fn get_new_branch_name(
+    config: &crate::config::Config,
+    jj: &crate::jj::Jujutsu,
+    commit_oid: Oid,
+    title: &str,
+) -> Result<String> {
+    find_unused_branch_name(config, jj, &slugify(title))
+}
+
+fn get_base_branch_name(
+    config: &crate::config::Config,
+    jj: &crate::jj::Jujutsu,
+    commit_oid: Oid,
+    title: &str,
+) -> Result<String> {
+    find_unused_branch_name(
+        config,
+        jj,
+        &format!("{}.{}", config.master_ref.branch_name(), &slugify(title)),
+    )
+}
+
+fn find_unused_branch_name(
+    config: &crate::config::Config,
+    jj: &crate::jj::Jujutsu,
+    slug: &str,
+) -> Result<String> {
+    let existing_ref_names = jj.get_all_ref_names()?;
+    let remote_name = &config.remote_name;
+    let branch_prefix = &config.branch_prefix;
+    let mut branch_name = format!("{branch_prefix}{slug}");
+    let mut suffix = 0;
+
+    loop {
+        let remote_ref = format!("refs/remotes/{remote_name}/{branch_name}");
+
+        if !existing_ref_names.contains(&remote_ref) {
+            return Ok(branch_name);
+        }
+
+        suffix += 1;
+        branch_name = format!("{branch_prefix}{slug}-{suffix}");
+    }
 }
 
 #[cfg(test)]

--- a/spr/src/config.rs
+++ b/spr/src/config.rs
@@ -15,6 +15,7 @@ pub struct Config {
     pub master_ref: GitHubBranch,
     pub branch_prefix: String,
     pub require_approval: bool,
+    pub use_jj_bookmark_names: bool,
 }
 
 impl Config {
@@ -25,6 +26,7 @@ impl Config {
         master_branch: String,
         branch_prefix: String,
         require_approval: bool,
+        use_jj_bookmark_names: bool,
     ) -> Self {
         let master_ref =
             GitHubBranch::new_from_branch_name(&master_branch, &remote_name, &master_branch);
@@ -35,6 +37,7 @@ impl Config {
             master_ref,
             branch_prefix,
             require_approval,
+            use_jj_bookmark_names,
         }
     }
 
@@ -193,6 +196,7 @@ mod tests {
             "origin".into(),
             "master".into(),
             "spr/foo/".into(),
+            false,
             false,
         )
     }

--- a/spr/src/config.rs
+++ b/spr/src/config.rs
@@ -5,9 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use std::collections::HashSet;
-
-use crate::{error::Result, github::GitHubBranch, utils::slugify};
+use crate::{error::Result, github::GitHubBranch};
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -71,39 +69,6 @@ impl Config {
         }
 
         None
-    }
-
-    pub fn get_new_branch_name(&self, existing_ref_names: &HashSet<String>, title: &str) -> String {
-        self.find_unused_branch_name(existing_ref_names, &slugify(title))
-    }
-
-    pub fn get_base_branch_name(
-        &self,
-        existing_ref_names: &HashSet<String>,
-        title: &str,
-    ) -> String {
-        self.find_unused_branch_name(
-            existing_ref_names,
-            &format!("{}.{}", self.master_ref.branch_name(), &slugify(title)),
-        )
-    }
-
-    fn find_unused_branch_name(&self, existing_ref_names: &HashSet<String>, slug: &str) -> String {
-        let remote_name = &self.remote_name;
-        let branch_prefix = &self.branch_prefix;
-        let mut branch_name = format!("{branch_prefix}{slug}");
-        let mut suffix = 0;
-
-        loop {
-            let remote_ref = format!("refs/remotes/{remote_name}/{branch_name}");
-
-            if !existing_ref_names.contains(&remote_ref) {
-                return branch_name;
-            }
-
-            suffix += 1;
-            branch_name = format!("{branch_prefix}{slug}-{suffix}");
-        }
     }
 
     pub fn new_github_branch_from_ref(&self, ghref: &str) -> Result<GitHubBranch> {

--- a/spr/src/git.rs
+++ b/spr/src/git.rs
@@ -928,6 +928,7 @@ mod tests {
             "main".into(),
             "spr/test/".into(),
             false,
+            false,
         )
     }
 

--- a/spr/src/jj.rs
+++ b/spr/src/jj.rs
@@ -332,6 +332,26 @@ impl Jujutsu {
         Ok(output.trim().to_string())
     }
 
+    /// Evaluate jj's `templates.git_push_bookmark` template for a commit to get
+    /// the bookmark name that `jj git push --change` would use.
+    pub fn get_jj_bookmark_name_for_commit(&self, commit_oid: Oid) -> Result<String> {
+        // Get the configured template (jj returns its built-in default if not configured)
+        let tmpl = self
+            .run_captured_with_args(["config", "get", "templates.git_push_bookmark"])?;
+        let tmpl = tmpl.trim().to_string();
+
+        let output = self.run_captured_with_args([
+            "log",
+            "--no-graph",
+            "-r",
+            &commit_oid.to_string(),
+            "--template",
+            &tmpl,
+        ])?;
+
+        Ok(output.trim().to_string())
+    }
+
     fn run_captured_with_args<I, S>(&self, args: I) -> Result<String>
     where
         I: IntoIterator<Item = S>,
@@ -461,6 +481,7 @@ mod tests {
             "origin".into(),
             "main".into(),
             "spr/test/".into(),
+            false,
             false,
         )
     }
@@ -690,6 +711,52 @@ mod tests {
         assert!(
             derived_committer_time.seconds() > original_committer_time.seconds(),
             "Derived commit committer timestamp should be newer than original"
+        );
+    }
+
+    #[test]
+    fn test_get_jj_bookmark_name_for_commit() {
+        let (_temp_dir, repo_path) = create_jujutsu_test_repo();
+
+        // Set a known template at repo level to isolate from user config.
+        // The value is a TOML single-quoted string containing the template expression.
+        let set_output = std::process::Command::new("jj")
+            .args([
+                "config",
+                "set",
+                "--repo",
+                "templates.git_push_bookmark",
+                r#"'"test-push-" ++ change_id.short()'"#,
+            ])
+            .current_dir(&repo_path)
+            .output()
+            .expect("Failed to run jj config set");
+        assert!(
+            set_output.status.success(),
+            "jj config set failed: {}",
+            String::from_utf8_lossy(&set_output.stderr)
+        );
+
+        let _commit = create_jujutsu_commit(&repo_path, "Test commit", "content");
+
+        let jj = Jujutsu::new(repo_path.clone()).expect("Failed to create Jujutsu instance");
+
+        let commit_oid = jj
+            .resolve_revision_to_commit_id("@-")
+            .expect("Failed to resolve revision");
+
+        let name = jj
+            .get_jj_bookmark_name_for_commit(commit_oid)
+            .expect("Failed to get bookmark name");
+
+        assert!(
+            name.starts_with("test-push-"),
+            "Expected bookmark name starting with 'test-push-', got: {}",
+            name
+        );
+        assert!(
+            name.len() > "test-push-".len(),
+            "Expected change ID suffix after 'test-push-'"
         );
     }
 }

--- a/spr/src/main.rs
+++ b/spr/src/main.rs
@@ -134,6 +134,8 @@ pub async fn spr() -> Result<()> {
     let branch_prefix = get_config_value("spr.branchPrefix", &git_config)
         .ok_or_else(|| Error::new("spr.branchPrefix must be configured".to_string()))?;
     let require_approval = get_config_bool("spr.requireApproval", &git_config).unwrap_or(false);
+    let use_jj_bookmark_names =
+        get_config_bool("spr.useJjBookmarkNames", &git_config).unwrap_or(false);
 
     let config = jj_spr::config::Config::new(
         github_owner,
@@ -142,6 +144,7 @@ pub async fn spr() -> Result<()> {
         github_master_branch,
         branch_prefix,
         require_approval,
+        use_jj_bookmark_names,
     );
 
     if let Commands::Format(opts) = cli.command {


### PR DESCRIPTION
I want to use the same branch names that would be created if I used `jj git push -c <>`.

In this PR I introduce spr.useJjBookmarkNames config option that would allow to turn this behavior on.

It works by running `jj log ... -T` and using the string as the branch name.